### PR TITLE
Fix 'PolygonUtil.simplify' bug

### DIFF
--- a/lib/src/polygon_util.dart
+++ b/lib/src/polygon_util.dart
@@ -346,7 +346,7 @@ class PolygonUtil {
     int idx;
     var maxIdx = 0;
     final stack = Queue<List<int>>();
-    final dists = List<num>(3);
+    final dists = List<num>.filled(n, 0);
     dists[0] = 1;
     dists[n - 1] = 1;
     num maxDist;


### PR DESCRIPTION
There two issue in 'simplify' function.
1. The length of `dists` is wrong. It should be same as `poly.length`.
2. `dists` need to assign default value 0.
In java `double[] dists = new double[n];` will create an array which all item default value is zero (Cause double is primitive type).
In dart `final dists = List<num>(0)` will create an array which all item default value is null.